### PR TITLE
1007 - Provide screen-reader-only text for links that open in new window/tab

### DIFF
--- a/js/linkAccessibility.js
+++ b/js/linkAccessibility.js
@@ -1,0 +1,36 @@
+(function ($, Drupal) {
+  "use strict";
+
+  /**
+   * @file
+   *
+   * Progressive enhancements to make links more accessible.
+   */
+  Drupal.behaviors.utexasLinkAccessibility = {
+    attach: function (context, settings) {
+      $('body a').each(function () {
+        modifyLink(this);
+      });
+    }
+  }
+
+  /**
+   * If a link has target="_blank"/"new", append an aria-label.
+   * @param {object} el The link element.
+   */
+  function modifyLink(el) {
+    let newWindowtext = "Link opens in new window";
+    var target = el.getAttribute('target');
+    if (target == '_blank' || target == 'new') {
+      var label = el.getAttribute('aria-label');
+      if (label == null) {
+        label = newWindowtext;
+      }
+      else {
+        label = label + '; ' + newWindowtext;
+      }
+      el.setAttribute('aria-label', label);
+    }
+  }
+
+})(jQuery, Drupal);

--- a/modules/custom/utexas_block_library_access/src/Plugin/Menu/LocalAction/UtexasBlockContentAddLocalAction.php
+++ b/modules/custom/utexas_block_library_access/src/Plugin/Menu/LocalAction/UtexasBlockContentAddLocalAction.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\utexas_block_library_access\Plugin\Menu\LocalAction;
 
-use Drupal\block_content\Plugin\Menu\LocalAction\BlockContentAddLocalAction;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
+use Drupal\block_content\Plugin\Menu\LocalAction\BlockContentAddLocalAction;
 
 /**
  * Modifies the 'Add custom block' local action.

--- a/modules/custom/utexas_block_social_links/src/Form/UtexasSocialLinksDataForm.php
+++ b/modules/custom/utexas_block_social_links/src/Form/UtexasSocialLinksDataForm.php
@@ -48,7 +48,7 @@ class UtexasSocialLinksDataForm extends EntityForm {
    * @param \Drupal\Core\File\FileSystemInterface $file_system
    *   The file handler.
    */
-  public function __construct(RendererInterface $renderer, MessengerInterface $messenger, FileSystemInterface $file_system = NULL) {
+  public function __construct(RendererInterface $renderer, MessengerInterface $messenger, ?FileSystemInterface $file_system = NULL) {
     $this->renderer = $renderer;
     $this->messenger = $messenger;
     $this->fileSystem = $file_system;

--- a/modules/custom/utexas_block_social_links/utexas_block_social_links.module
+++ b/modules/custom/utexas_block_social_links/utexas_block_social_links.module
@@ -5,10 +5,10 @@
  * Defines additional configuration for utexas_block_social_links.
  */
 
-use Drupal\block\Entity\Block;
-use Drupal\block_content\Entity\BlockContent;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
+use Drupal\block\Entity\Block;
+use Drupal\block_content\Entity\BlockContent;
 
 /**
  * Implements hook_field_widget_form_alter().

--- a/modules/custom/utexas_call_to_action/config/install/core.entity_form_display.block_content.call_to_action.default.yml
+++ b/modules/custom/utexas_call_to_action/config/install/core.entity_form_display.block_content.call_to_action.default.yml
@@ -12,13 +12,15 @@ bundle: call_to_action
 mode: default
 content:
   field_utexas_call_to_action_link:
+    type: utexas_link_widget
     weight: 28
+    region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
+      linkit_profile: flex_html
+      linkit_auto_link_text: 0
     third_party_settings: {  }
-    type: utexas_link_widget
-    region: content
   info:
     type: string_textfield
     weight: -5

--- a/modules/custom/utexas_call_to_action/config/install/core.entity_view_display.block_content.call_to_action.default.yml
+++ b/modules/custom/utexas_call_to_action/config/install/core.entity_view_display.block_content.call_to_action.default.yml
@@ -6,7 +6,6 @@ dependencies:
     - field.field.block_content.call_to_action.field_utexas_call_to_action_link
   module:
     - layout_builder
-    - layout_discovery
     - utexas_call_to_action
 third_party_settings:
   layout_builder:

--- a/modules/custom/utexas_call_to_action/utexas_call_to_action.info.yml
+++ b/modules/custom/utexas_call_to_action/utexas_call_to_action.info.yml
@@ -3,13 +3,13 @@ description: 'Provides a custom block type with a formatted link field.'
 type: module
 core_version_requirement: '^10 || ^11'
 dependencies:
-  - block_content
-  - field
-  - layout_builder
-  - layout_discovery
-  - link
-  - text
-  - utexas_call_to_action
-  - utexas_form_elements
+  - 'drupal:block_content'
+  - 'drupal:field'
+  - 'drupal:layout_builder'
+  - 'drupal:layout_discovery'
+  - 'drupal:link'
+  - 'drupal:text'
+  - 'utexas_call_to_action:utexas_call_to_action'
+  - 'utexas_form_elements:utexas_form_elements'
 package: UTexas
 core_incompatible: false

--- a/modules/custom/utexas_call_to_action/utexas_call_to_action.install
+++ b/modules/custom/utexas_call_to_action/utexas_call_to_action.install
@@ -13,3 +13,12 @@ function utexas_call_to_action_update_8101() {
     'utexas_call_to_action',
   ], TRUE);
 }
+
+/**
+ * Update link widget to use Linkit settings (#2655).
+ */
+function utexas_call_to_action_update_8102() {
+  \Drupal::service('features.manager')->import([
+    'utexas_call_to_action',
+  ], TRUE);
+}

--- a/modules/custom/utexas_featured_highlight/utexas_featured_highlight.module
+++ b/modules/custom/utexas_featured_highlight/utexas_featured_highlight.module
@@ -5,8 +5,8 @@
  * Contains utexas_featured_highlight.module.
  */
 
-use Drupal\block\BlockForm;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\block\BlockForm;
 
 /**
  * Implements hook_theme().

--- a/modules/custom/utexas_form_elements/src/Plugin/Field/FieldWidget/UtexasLinkWidget.php
+++ b/modules/custom/utexas_form_elements/src/Plugin/Field/FieldWidget/UtexasLinkWidget.php
@@ -4,7 +4,7 @@ namespace Drupal\utexas_form_elements\Plugin\Field\FieldWidget;
 
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\link\Plugin\Field\FieldWidget\LinkWidget;
+use Drupal\linkit\Plugin\Field\FieldWidget\LinkitWidget;
 use Drupal\utexas_form_elements\UtexasLinkOptionsHelper;
 
 /**
@@ -18,7 +18,7 @@ use Drupal\utexas_form_elements\UtexasLinkOptionsHelper;
  *   }
  * )
  */
-class UtexasLinkWidget extends LinkWidget {
+class UtexasLinkWidget extends LinkitWidget {
 
   /**
    * {@inheritdoc}

--- a/modules/custom/utexas_form_elements/src/UtexasLinkOptionsHelper.php
+++ b/modules/custom/utexas_form_elements/src/UtexasLinkOptionsHelper.php
@@ -25,7 +25,7 @@ class UtexasLinkOptionsHelper {
    * @return array
    *   The link element with options added.
    */
-  public function addLinkOptions(array $element, LinkItemInterface $item = NULL) {
+  public function addLinkOptions(array $element, ?LinkItemInterface $item = NULL) {
     // Add validation for the two listed elements to the parent element.
     $element['#element_validate'][] = [get_called_class(), 'validateLinkOptionsTarget'];
     $element['#element_validate'][] = [get_called_class(), 'validateLinkOptionsClass'];
@@ -82,7 +82,7 @@ class UtexasLinkOptionsHelper {
    * @return array
    *   The link element with link option defaults added.
    */
-  private function addLinkOptionsDefaults(array $element, LinkItemInterface $item = NULL) {
+  private function addLinkOptionsDefaults(array $element, ?LinkItemInterface $item = NULL) {
     // When a widget calls this method, we use the $item to access an 'options'
     // object. When another form element calls this method, we can access the
     // 'options' array directly.
@@ -110,7 +110,7 @@ class UtexasLinkOptionsHelper {
    * @return object
    *   The prepared link object.
    */
-  public static function buildLink(array $item, array $link_add_classes = [], string $link_title_override = NULL) {
+  public static function buildLink(array $item, array $link_add_classes = [], ?string $link_title_override = NULL) {
     // If no uri, return null.
     if (empty($item['link']['uri'])) {
       return NULL;

--- a/modules/custom/utexas_form_elements/utexas_form_elements.info.yml
+++ b/modules/custom/utexas_form_elements/utexas_form_elements.info.yml
@@ -3,6 +3,8 @@ type: module
 description: General-use form elements not provided by Core
 core_version_requirement: '^10 || ^11'
 package: UTexas
+dependencies:
+  - 'linkit:linkit'
 
 ckeditor5-stylesheets:
   - css/link-options.css

--- a/modules/custom/utexas_hero/utexas_hero.module
+++ b/modules/custom/utexas_hero/utexas_hero.module
@@ -5,8 +5,8 @@
  * Contains utexas_hero.module.
  */
 
-use Drupal\block\BlockForm;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\block\BlockForm;
 
 /**
  * Implements hook_theme().

--- a/modules/custom/utexas_hero_carousel/utexas_hero_carousel.module
+++ b/modules/custom/utexas_hero_carousel/utexas_hero_carousel.module
@@ -5,9 +5,9 @@
  * Contains Project listing block type .module file.
  */
 
-use Drupal\block_content\Entity\BlockContent;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\block_content\Entity\BlockContent;
 
 /**
  * Implements hook_entity_view_alter().

--- a/modules/custom/utexas_instagram_api/src/Controller/InstagramAuthListController.php
+++ b/modules/custom/utexas_instagram_api/src/Controller/InstagramAuthListController.php
@@ -26,7 +26,7 @@ class InstagramAuthListController extends ControllerBase {
    *   A render array as expected by
    *   \Drupal\Core\Render\RendererInterface::render().
    */
-  public function listing(Request $request = NULL) {
+  public function listing(?Request $request = NULL) {
 
     // Get URL paramters following successful Instagram Account OAuth request.
     $code = $request->query->get('code', NULL);

--- a/modules/custom/utexas_promo_list/utexas_promo_list.module
+++ b/modules/custom/utexas_promo_list/utexas_promo_list.module
@@ -5,8 +5,8 @@
  * Contains utexas_promo_list.module.
  */
 
-use Drupal\block\BlockForm;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\block\BlockForm;
 
 /**
  * Implements hook_theme().

--- a/modules/custom/utexas_promo_unit/utexas_promo_unit.module
+++ b/modules/custom/utexas_promo_unit/utexas_promo_unit.module
@@ -5,8 +5,8 @@
  * Contains utexas_promo_unit.module.
  */
 
-use Drupal\block\BlockForm;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\block\BlockForm;
 
 /**
  * Implements hook_theme().

--- a/modules/custom/utexas_qualtrics_filter/tests/src/Unit/FilterQualtricsTest.php
+++ b/modules/custom/utexas_qualtrics_filter/tests/src/Unit/FilterQualtricsTest.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\Tests\utexas_qualtrics_filter\Unit;
 
-use Drupal\filter\Plugin\Filter\FilterHtml;
 use Drupal\Tests\UnitTestCase;
+use Drupal\filter\Plugin\Filter\FilterHtml;
 use Drupal\utexas_qualtrics_filter\Plugin\Filter\FilterQualtrics;
 
 /**

--- a/modules/custom/utexas_quick_links/utexas_quick_links.module
+++ b/modules/custom/utexas_quick_links/utexas_quick_links.module
@@ -5,8 +5,8 @@
  * Quick Links custom compound field dot module file.
  */
 
-use Drupal\block\BlockForm;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\block\BlockForm;
 
 /**
  * Implements hook_theme().

--- a/modules/custom/utexas_resources/utexas_resources.module
+++ b/modules/custom/utexas_resources/utexas_resources.module
@@ -5,8 +5,8 @@
  * Resources custom compound field dot module file.
  */
 
-use Drupal\block\BlockForm;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\block\BlockForm;
 
 /**
  * Implements hook_theme().

--- a/modules/custom/utexas_site_announcement/src/Form/AnnouncementConfigurationForm.php
+++ b/modules/custom/utexas_site_announcement/src/Form/AnnouncementConfigurationForm.php
@@ -2,12 +2,12 @@
 
 namespace Drupal\utexas_site_announcement\Form;
 
-use Drupal\block\Entity\Block;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Markup;
+use Drupal\block\Entity\Block;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**

--- a/modules/custom/utexas_site_announcement/src/Form/UTexasAnnouncementIconDeleteForm.php
+++ b/modules/custom/utexas_site_announcement/src/Form/UTexasAnnouncementIconDeleteForm.php
@@ -29,7 +29,7 @@ class UTexasAnnouncementIconDeleteForm extends EntityConfirmFormBase {
    * @param \Drupal\Core\File\FileSystemInterface $file_system
    *   The file system.
    */
-  public function __construct(FileSystemInterface $file_system = NULL) {
+  public function __construct(?FileSystemInterface $file_system = NULL) {
     $this->fileSystem = $file_system;
   }
 

--- a/modules/custom/utexas_site_announcement/src/Form/UTexasAnnouncementIconForm.php
+++ b/modules/custom/utexas_site_announcement/src/Form/UTexasAnnouncementIconForm.php
@@ -48,7 +48,7 @@ class UTexasAnnouncementIconForm extends EntityForm {
    * @param \Drupal\Core\File\FileSystemInterface $file_system
    *   The file handler.
    */
-  public function __construct(RendererInterface $renderer, MessengerInterface $messenger, FileSystemInterface $file_system = NULL) {
+  public function __construct(RendererInterface $renderer, MessengerInterface $messenger, ?FileSystemInterface $file_system = NULL) {
     $this->renderer = $renderer;
     $this->messenger = $messenger;
     $this->fileSystem = $file_system;

--- a/modules/custom/utexas_site_announcement/src/Plugin/Block/AnnouncementBlock.php
+++ b/modules/custom/utexas_site_announcement/src/Plugin/Block/AnnouncementBlock.php
@@ -47,7 +47,7 @@ class AnnouncementBlock extends BlockBase implements ContainerFactoryPluginInter
    * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
    *   The entity type manager.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManager $entity_type_manager) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ?EntityTypeManager $entity_type_manager = NULL) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entity_type_manager;
   }

--- a/modules/custom/utexas_site_announcement/src/Plugin/Block/AnnouncementBlock.php
+++ b/modules/custom/utexas_site_announcement/src/Plugin/Block/AnnouncementBlock.php
@@ -47,7 +47,7 @@ class AnnouncementBlock extends BlockBase implements ContainerFactoryPluginInter
    * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
    *   The entity type manager.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManager $entity_type_manager = NULL) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManager $entity_type_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entity_type_manager;
   }
@@ -77,7 +77,7 @@ class AnnouncementBlock extends BlockBase implements ContainerFactoryPluginInter
         'homepage' => $this->t("Active on homepage only"),
         'all' => $this->t("Active on all pages"),
       ],
-      '#default_value' => $config['status'] ?? 'inactive',
+      '#default_value' => $config['state'] ?? 'inactive',
     ];
     $form['title'] = [
       '#type' => 'textfield',

--- a/src/Form/InstallationComplete.php
+++ b/src/Form/InstallationComplete.php
@@ -49,7 +49,7 @@ class InstallationComplete extends FormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, array &$install_state = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state, ?array &$install_state = NULL) {
     // Do a cache rebuild to ensure all components are registered.
     // We intermittently saw site installations initially result in PHP fatal
     // errors, so this is a preventative measure.

--- a/src/Form/InstallationOptions.php
+++ b/src/Form/InstallationOptions.php
@@ -62,7 +62,7 @@ class InstallationOptions extends FormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, array &$install_state = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state, ?array &$install_state = NULL) {
     $form['#title'] = $this->t('Installation options');
     $form['default_content'] = [
       '#type' => 'checkbox',

--- a/src/InstallationHelper.php
+++ b/src/InstallationHelper.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\utexas;
 
-use Drupal\block\Entity\Block;
 use Drupal\Core\File\FileSystemInterface;
+use Drupal\block\Entity\Block;
 use Drupal\file\Entity\File;
 use Symfony\Component\Yaml\Yaml;
 

--- a/tests/src/Functional/BaseInstallationTest.php
+++ b/tests/src/Functional/BaseInstallationTest.php
@@ -4,15 +4,12 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\utexas\Functional;
 
-use Drupal\filter\Entity\FilterFormat;
-
-use Drupal\node\Entity\Node;
-
 use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\utexas\Traits\EntityTestTrait;
 use Drupal\Tests\utexas\Traits\InstallTestTrait;
 use Drupal\Tests\utexas\Traits\UserTestTrait;
-
+use Drupal\filter\Entity\FilterFormat;
+use Drupal\node\Entity\Node;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**

--- a/tests/src/FunctionalJavascript/FunctionalJavascriptTestBase.php
+++ b/tests/src/FunctionalJavascript/FunctionalJavascriptTestBase.php
@@ -9,8 +9,8 @@ use Behat\Mink\Element\TraversableElement;
 use Drupal\Core\Database\Database;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
-use Drupal\Tests\contextual\FunctionalJavascript\ContextualLinkClickTrait;
 use Drupal\Tests\TestFileCreationTrait;
+use Drupal\Tests\contextual\FunctionalJavascript\ContextualLinkClickTrait;
 use Drupal\Tests\utexas\Traits\EntityTestTrait;
 use Drupal\Tests\utexas\Traits\InstallTestTrait;
 use Drupal\Tests\utexas\Traits\UserTestTrait;
@@ -896,7 +896,7 @@ abstract class FunctionalJavascriptTestBase extends WebDriverTestBase {
    * @param string $selector
    *   The xpath selector.
    */
-  protected function assertNotEmptyXpath(NodeElement $element = NULL, $selector) {
+  protected function assertNotEmptyXpath(NodeElement $element, $selector) {
     $message = 'No element matching xpath selector "' . $selector . '" was found, or the element is otherwise unavailable.';
     $this->assertNotEmpty($element, $message);
   }

--- a/tests/src/Traits/WidgetsTestTraits/FlexContentAreaTestTrait.php
+++ b/tests/src/Traits/WidgetsTestTraits/FlexContentAreaTestTrait.php
@@ -139,6 +139,7 @@ trait FlexContentAreaTestTrait {
     $fieldsets = $page->findAll('css', 'div.field--type-utexas-flex-content-area details');
     $fieldsets[0]->click();
     $page->pressButton('image-0-media-library-remove-button-field_block_fca-0-flex_content_area');
+    $session->wait(3000);
     $this->assertTrue($assert->waitForText('One media item remaining.'));
     $session->wait(3000);
     $page->pressButton('Add media');

--- a/utexas.install
+++ b/utexas.install
@@ -5,8 +5,8 @@
  * Install and uninstall functions for the UTexas profile.
  */
 
-use Drupal\block\Entity\Block;
 use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\block\Entity\Block;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\user\RoleInterface;

--- a/utexas.install
+++ b/utexas.install
@@ -1135,3 +1135,12 @@ function utexas_update_8162() {
 function utexas_update_8163() {
   drupal_flush_all_caches();
 }
+
+/**
+ * Uninstall Layout Builder Expose Field Blocks (#2636).
+ */
+function utexas_update_8164() {
+  if (\Drupal::moduleHandler()->moduleExists('layout_builder_expose_all_field_blocks') === TRUE) {
+    \Drupal::service('module_installer')->uninstall(['layout_builder_expose_all_field_blocks']);
+  }
+}

--- a/utexas.libraries.yml
+++ b/utexas.libraries.yml
@@ -1,6 +1,7 @@
 auto-anchors:
   js:
     js/autoAnchors.js: {}
+    js/linkAccessibility.js: []
 utexas-install:
   css:
     theme:

--- a/utexas.profile
+++ b/utexas.profile
@@ -5,10 +5,10 @@
  * Enables modules and site configuration for a standard UTDK installation.
  */
 
-use Drupal\block\Entity\Block;
-use Drupal\block_content\Entity\BlockContent;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\block\Entity\Block;
+use Drupal\block_content\Entity\BlockContent;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\user\Entity\User;
 use Drupal\utexas\Form\InstallationComplete;


### PR DESCRIPTION
## Purpose
Resolves #1007

## Acceptance criteria
- [ ] Any link that has `target="_blank"` ([standard](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target)) or "target="new" (legacy) will automatically render `aria-label="Link opens in new window"`
- [ ] If a link already contains `aria-label` text, the text `; Link opens in new window` will be appended to the existing label.

![Screenshot from 2024-10-16 09-31-27](https://github.com/user-attachments/assets/b23561c2-6b38-4d1d-8a1f-e1ce6b52123f)


## Pull request creator checklist
In order to be reviewed, all items must be checked by the pull request creator.
- [x] I updated the issue title & description to reflect the final state of these changes
- [x] I considered whether test coverage should be added
- [x] I considered whether this needs a `needs-documentation` or `visual-change` label on the issue
- [x] I considered whether this change accommodates new and existing sites